### PR TITLE
Add support for Ghostty terminal

### DIFF
--- a/src/supported_terminals.rs
+++ b/src/supported_terminals.rs
@@ -22,6 +22,7 @@ pub static SUPPORTED_TERMINALS: LazyLock<Vec<SupportedTerminal>> = LazyLock::new
         ("Foot", "footclient", "-e"),
         ("Xterm", "xterm", "-e"),
         ("COSMIC Terminal", "cosmic-term", "-e"),
+        ("Ghostty", "ghostty", "-e"),
     ]
     .iter()
     .map(|(name, program, separator_arg)| SupportedTerminal {

--- a/src/terminal_combo_row.rs
+++ b/src/terminal_combo_row.rs
@@ -31,10 +31,12 @@ mod imp {
             obj.set_title("Preferred Terminal");
             obj.set_use_subtitle(true);
 
-            let terminals = SUPPORTED_TERMINALS
+            let mut terminals = SUPPORTED_TERMINALS
                 .iter()
                 .map(|x| x.name.as_ref())
                 .collect::<Vec<&str>>();
+            // case-insensitive sort
+            terminals.sort_by(|a, b| a.to_lowercase().cmp(&b.to_lowercase()));
             let selected_position = terminals.iter().position(|x| {
                 Some(x)
                     == obj


### PR DESCRIPTION
* Add support for Ghostty terminal

Ghostty has become really popular so I think it makes
sense support it.

* Sort terminals alphabetically in preferences

If you're looking for a specific terminal, it can
be confusing since there's no logical sorting for
the list of terminals.

Before:
![Screenshot From 2025-05-10 17-31-34](https://github.com/user-attachments/assets/0b4a84c7-3137-4a5c-af14-2bcee7ddf78c)

After:
![Screenshot From 2025-05-10 17-31-00](https://github.com/user-attachments/assets/facaed53-f3b2-4e65-b32c-a87ab3adbb7d)
