### PR TITLE
Update metainfo so app shows as mobile friendly in Flathub

### DIFF
--- a/data/com.ranfdev.DistroShelf.metainfo.xml.in
+++ b/data/com.ranfdev.DistroShelf.metainfo.xml.in
@@ -58,6 +58,15 @@
     <color type="primary" scheme_preference="dark">#241f31</color>
   </branding>
 
+  <supports>
+    <control>keyboard</control>
+    <control>pointing</control>
+    <control>touch</control>
+  </supports>
+  <requires>
+    <display_length compare="ge">360</display_length>
+  </requires>
+
   <screenshots>
     <screenshot type="default">
       <image type="source">https://raw.githubusercontent.com/ranfdev/DistroShelf/master/data/screenshots/1.png</image>


### PR DESCRIPTION
Follow up to #69 . This change will allow the app to show up in https://flathub.org/en/apps/collection/mobile/

This can be checked using: `appstreamcli check-syscompat ./data/com.ranfdev.DistroShelf.metainfo.xml.in`

Before:
```bash
Chassis compatibility check for: */*/*/com.ranfdev.DistroShelf/*

Desktop:
 ✔ Compatible (100%)

Laptop:
 ✔ Compatible (100%)

Server:
 ✘ Incompatible

Tablet:
 ✘ Incompatible

Handset:
 ✘ Incompatible

```

After:
```bash
Chassis compatibility check for: */*/*/com.ranfdev.DistroShelf/*

Desktop:
 ✔ Compatible (100%)

Laptop:
 ✔ Compatible (100%)

Server:
 ✘ Incompatible

Tablet:
 ✔ Compatible (100%)

Handset:
 ✔ Compatible (100%)

```