### PR TITLE
fix: start container terminal from container home

### DIFF
--- a/src/backends/distrobox/distrobox.rs
+++ b/src/backends/distrobox/distrobox.rs
@@ -1093,7 +1093,7 @@ impl Distrobox {
     // enter
     pub fn enter_cmd(&self, name: &str) -> Command {
         let mut cmd = self.dbcmd();
-        cmd.arg("enter").arg(name);
+        cmd.arg("enter").arg(name).arg("--no-workdir");
         cmd
     }
     // clone from an existing container using create args to customize the clone


### PR DESCRIPTION
Fixes #96

`distrobox enter` was preserving the host cwd, which lands in the wrong place when the container uses a different home path. This adds `--no-workdir` so terminal sessions start from the container default location.

Greetings, saschabuehrle
