### PR TITLE
Fix several user-facing messages not marked as translated

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -12,6 +12,7 @@ src/dialogs/task_manager_dialog.rs
 src/widgets/container_overview.rs
 src/widgets/image_row_item.rs
 src/widgets/integrated_terminal.rs
+src/widgets/tasks_button.rs
 src/widgets/terminal_combo_row.rs
 src/widgets/welcome_view.rs
 src/widgets/welcome_view.ui

--- a/src/dialogs/create_distrobox_dialog.rs
+++ b/src/dialogs/create_distrobox_dialog.rs
@@ -190,11 +190,11 @@ mod imp {
 
             // Add pages to view stack
             self.view_stack
-                .add_titled(&guided_page, Some("create"), "Guided");
+                .add_titled(&guided_page, Some("create"), &gettext("Guided"));
             self.view_stack
-                .add_titled(&assemble_page, Some("assemble-file"), "From File");
+                .add_titled(&assemble_page, Some("assemble-file"), &gettext("From File"));
             self.view_stack
-                .add_titled(&url_page, Some("assemble-url"), "From URL");
+                .add_titled(&url_page, Some("assemble-url"), &gettext("From URL"));
 
             // Create a box to hold the view switcher and content
             let content_box = gtk::Box::new(gtk::Orientation::Vertical, 0);
@@ -225,7 +225,7 @@ mod imp {
             toolbar_view.set_vexpand(true);
             toolbar_view.set_content(Some(&self.toast_overlay));
 
-            let page = adw::NavigationPage::new(toolbar_view, "Create a Distrobox");
+            let page = adw::NavigationPage::new(toolbar_view, &gettext("Create a Distrobox"));
             navigation_view.add(&page);
             self.obj().set_child(Some(navigation_view));
 

--- a/src/dialogs/task_manager_dialog.rs
+++ b/src/dialogs/task_manager_dialog.rs
@@ -99,7 +99,7 @@ mod imp {
 
             self.navigation_view.add(&adw::NavigationPage::new(
                 &self.toolbar_view,
-                "Manage Tasks",
+                &gettext("Manage Tasks"),
             ));
             let this = self.obj().clone();
             if root_store.tasks().is_empty() {
@@ -135,7 +135,7 @@ mod imp {
                     }
                     this.imp()
                         .navigation_view
-                        .push(&adw::NavigationPage::new(stv, "Task Details"));
+                        .push(&adw::NavigationPage::new(stv, &gettext("Task Details")));
                 }
             });
             let this = self.obj().clone();

--- a/src/widgets/tasks_button.rs
+++ b/src/widgets/tasks_button.rs
@@ -1,3 +1,4 @@
+use crate::i18n::gettext;
 use crate::models::{DialogType, DistroboxTask, RootStore};
 use adw::prelude::*;
 use adw::subclass::prelude::*;
@@ -44,7 +45,7 @@ mod imp {
 
             // Create a horizontal box with a "Tasks" label and warning icon
             let hbox = gtk::Box::new(gtk::Orientation::Horizontal, 6);
-            let label = gtk::Label::new(Some("Tasks"));
+            let label = gtk::Label::new(Some(&gettext("Tasks")));
             let warning_icon = &self.warning_icon;
             warning_icon.set_hexpand(true);
             warning_icon.set_halign(gtk::Align::End);


### PR DESCRIPTION
While working on a translation, I noticed several human-facing messages are not marked as translatable. These are:

- The "Tasks" button to open the tasks dialog
- The title of the tasks dialog ("Manage Tasks"), and the title of the "Task Details" page
- The "Guided" / "From File" / "From URL" choices in the create distrobox dialog, and its window title ("Create a Distrobox")

I have built and tested this to make sure it works. With this fix these strings can then be translated.
